### PR TITLE
Hv ffi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,7 @@
 # Debug files
 *.dSYM/
 /vmm
+
+# xhype
+xhype/xhype/target
+xhype/xhype/Cargo.lock

--- a/xhype/xhype/Cargo.toml
+++ b/xhype/xhype/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2018"
 
 
 [dependencies]
+libc = "0.2.66"

--- a/xhype/xhype/Cargo.toml
+++ b/xhype/xhype/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "xhype"
+version = "0.1.0"
+authors = ["Lencerf <changyuan.lv@gmail.com>"]
+edition = "2018"
+
+
+[dependencies]

--- a/xhype/xhype/build.rs
+++ b/xhype/xhype/build.rs
@@ -1,0 +1,5 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+
+fn main() {
+    println!("cargo:rustc-link-lib=framework=Hypervisor");
+}

--- a/xhype/xhype/src/hv/ffi.rs
+++ b/xhype/xhype/src/hv/ffi.rs
@@ -1,0 +1,162 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+
+//! Bindings to the Hypervisor Framework
+
+use libc::*;
+
+/// Hypervisor Framework return code
+pub type hv_return_t = u32;
+
+// Hypervisor Framework return codes
+pub const HV_SUCCESS: hv_return_t = 0;
+pub const HV_ERROR: hv_return_t = 0xfae94001;
+pub const HV_BUSY: hv_return_t = 0xfae94002;
+pub const HV_BAD_ARGUMENT: hv_return_t = 0xfae94003;
+pub const HV_NO_RESOURCES: hv_return_t = 0xfae94005;
+pub const HV_NO_DEVICE: hv_return_t = 0xfae94006;
+pub const HV_UNSUPPORTED: hv_return_t = 0xfae9400f;
+
+/// Options for hv_vcpu_create()
+pub type hv_vm_options_t = u64;
+pub const HV_VM_DEFAULT: hv_vm_options_t = 0 << 0;
+
+// Creating and Destroying VM Instances
+extern "C" {
+    /// Creates a VM instance for the current Mach task
+    pub fn hv_vm_create(flags: hv_vm_options_t) -> hv_return_t;
+
+    /// Destroys the VM instance associated with the current Mach task
+    pub fn hv_vm_destroy() -> hv_return_t;
+}
+
+/// Type of a vCPU ID
+pub type hv_vcpuid_t = c_uint;
+
+// Option for hv_vcpu_create()
+pub const HV_VCPU_DEFAULT: u64 = 0;
+
+// Creating and Managing vCPU Instances
+extern "C" {
+    /// Creates a vCPU instance for the current thread
+    pub fn hv_vcpu_create(vcpu: *mut hv_vcpuid_t, flags: hv_vm_options_t) -> hv_return_t;
+
+    /// Executes a vCPU
+    pub fn hv_vcpu_run(vcpu: hv_vcpuid_t) -> hv_return_t;
+
+    /// Forces an immediate VMEXIT of a set of vCPUs of the VM
+    pub fn hv_vcpu_interrupt(vcpu: *const hv_vcpuid_t, vcpu_count: c_uint) -> hv_return_t;
+
+    /// Returns the cumulative execution time of a vCPU in nanoseconds
+    pub fn hv_vcpu_get_exec_time(vcpu: hv_vcpuid_t, time: *mut u64) -> hv_return_t;
+
+    /// Forces flushing of cached vCPU state
+    pub fn hv_vcpu_flush(vcpu: hv_vcpuid_t) -> hv_return_t;
+
+    /// Invalidates the TLB of a vCPU
+    pub fn hv_vcpu_invalidate_tlb(vcpu: hv_vcpuid_t) -> hv_return_t;
+
+    /// Destroys the vCPU instance associated with the current thread
+    pub fn hv_vcpu_destroy(vcpu: hv_vcpuid_t) -> hv_return_t;
+}
+
+// Accessing Registers
+extern "C" {
+    /// Returns the current value of an architectural x86 register
+    /// of a vCPU
+    pub fn hv_vcpu_read_register(
+        vcpu: hv_vcpuid_t,
+        reg: super::x86Reg,
+        value: *mut u64,
+    ) -> hv_return_t;
+
+    /// Sets the value of an architectural x86 register of a vCPU
+    pub fn hv_vcpu_write_register(vcpu: hv_vcpuid_t, reg: super::x86Reg, value: u64)
+        -> hv_return_t;
+}
+
+// Accessing Floating Point (FP) State
+extern "C" {
+    /// Returns the current architectural x86 floating point and
+    /// SIMD state of a vCPU
+    pub fn hv_vcpu_read_fpstate(
+        vcpu: hv_vcpuid_t,
+        buffer: *mut c_void,
+        size: size_t,
+    ) -> hv_return_t;
+
+    /// Sets the architectural x86 floating point and SIMD state of
+    /// a vCPU
+    pub fn hv_vcpu_write_fpstate(
+        vcpu: hv_vcpuid_t,
+        buffer: *const c_void,
+        size: size_t,
+    ) -> hv_return_t;
+}
+
+// Accessing Machine Specific Registers (MSRs)
+extern "C" {
+    /// Enables an MSR to be used natively by the VM
+    pub fn hv_vcpu_enable_native_msr(vcpu: hv_vcpuid_t, msr: u32, enable: bool) -> hv_return_t;
+
+    /// Returns the current value of an MSR of a vCPU
+    pub fn hv_vcpu_read_msr(vcpu: hv_vcpuid_t, msr: u32, value: *mut u64) -> hv_return_t;
+
+    /// Set the value of an MSR of a vCPU
+    pub fn hv_vcpu_write_msr(vcpu: hv_vcpuid_t, msr: u32, value: *const u64) -> hv_return_t;
+}
+
+// Managing Timestamp-Counters (TSC)
+extern "C" {
+    /// Synchronizes guest Timestamp-Counters (TSC) across all vCPUs
+    pub fn hv_vm_sync_tsc(tsc: u64) -> hv_return_t;
+}
+
+/// Type of a user virtual address
+pub type hv_uvaddr_t = *const c_void;
+
+/// Guest physical memory region permissions for hv_vm_map()
+/// and hv_vm_protect()
+pub type hv_memory_flags_t = u64;
+
+/// Type of a guest physical address
+pub type hv_gpaddr_t = u64;
+
+// Guest physical memory region permissions for hv_vm_map() and hv_vm_protect()
+pub const HV_MEMORY_READ: hv_memory_flags_t = 1 << 0;
+pub const HV_MEMORY_WRITE: hv_memory_flags_t = 1 << 1;
+pub const HV_MEMORY_EXEC: hv_memory_flags_t = 1 << 2;
+
+// Managing Memory Regions
+extern "C" {
+    /// Maps a region in the virtual address space of the current
+    /// task into the guest physical address space of the VM
+    pub fn hv_vm_map(
+        uva: hv_uvaddr_t,
+        gpa: hv_gpaddr_t,
+        size: size_t,
+        flags: hv_memory_flags_t,
+    ) -> hv_return_t;
+
+    /// Unmaps a region in the guest physical address space of the VM
+    pub fn hv_vm_unmap(gpa: hv_gpaddr_t, size: size_t) -> hv_return_t;
+
+    /// Modifies the permissions of a region in the guest physical
+    /// address space of the VM
+    pub fn hv_vm_protect(gpa: hv_gpaddr_t, size: size_t, flags: hv_memory_flags_t) -> hv_return_t;
+}
+
+// Managing Virtual Machine Control Structure (VMCS)
+extern "C" {
+    /// Returns the current value of a VMCS field of a vCPU
+    pub fn hv_vmx_vcpu_read_vmcs(vcpu: hv_vcpuid_t, field: u32, value: *mut u64) -> hv_return_t;
+
+    /// Sets the value of a VMCS field of a vCPU
+    pub fn hv_vmx_vcpu_write_vmcs(vcpu: hv_vcpuid_t, field: u32, value: u64) -> hv_return_t;
+
+    /// Returns the VMX capabilities of the host processor
+    pub fn hv_vmx_read_capability(field: super::VMXCap, value: *mut u64) -> hv_return_t;
+
+    /// Sets the address of the guest APIC for a vCPU in the
+    /// guest physical address space of the VM
+    pub fn hv_vmx_vcpu_set_apic_address(vcpu: hv_vcpuid_t, gpa: hv_gpaddr_t) -> hv_return_t;
+}

--- a/xhype/xhype/src/hv/ffi.rs
+++ b/xhype/xhype/src/hv/ffi.rs
@@ -16,7 +16,7 @@ pub const HV_NO_RESOURCES: hv_return_t = 0xfae94005;
 pub const HV_NO_DEVICE: hv_return_t = 0xfae94006;
 pub const HV_UNSUPPORTED: hv_return_t = 0xfae9400f;
 
-/// Options for hv_vcpu_create()
+/// Options for hv_vm_create()
 pub type hv_vm_options_t = u64;
 pub const HV_VM_DEFAULT: hv_vm_options_t = 0 << 0;
 
@@ -65,12 +65,12 @@ extern "C" {
     /// of a vCPU
     pub fn hv_vcpu_read_register(
         vcpu: hv_vcpuid_t,
-        reg: super::x86Reg,
+        reg: super::X86Reg,
         value: *mut u64,
     ) -> hv_return_t;
 
     /// Sets the value of an architectural x86 register of a vCPU
-    pub fn hv_vcpu_write_register(vcpu: hv_vcpuid_t, reg: super::x86Reg, value: u64)
+    pub fn hv_vcpu_write_register(vcpu: hv_vcpuid_t, reg: super::X86Reg, value: u64)
         -> hv_return_t;
 }
 
@@ -102,7 +102,7 @@ extern "C" {
     pub fn hv_vcpu_read_msr(vcpu: hv_vcpuid_t, msr: u32, value: *mut u64) -> hv_return_t;
 
     /// Set the value of an MSR of a vCPU
-    pub fn hv_vcpu_write_msr(vcpu: hv_vcpuid_t, msr: u32, value: *const u64) -> hv_return_t;
+    pub fn hv_vcpu_write_msr(vcpu: hv_vcpuid_t, msr: u32, value: u64) -> hv_return_t;
 }
 
 // Managing Timestamp-Counters (TSC)

--- a/xhype/xhype/src/hv/mod.rs
+++ b/xhype/xhype/src/hv/mod.rs
@@ -1,0 +1,80 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+mod ffi;
+
+/// x86 architectural register
+#[allow(non_camel_case_types)]
+#[derive(Clone)]
+#[repr(C)]
+pub enum x86Reg {
+    RIP,
+    RFLAGS,
+    RAX,
+    RCX,
+    RDX,
+    RBX,
+    RSI,
+    RDI,
+    RSP,
+    RBP,
+    R8,
+    R9,
+    R10,
+    R11,
+    R12,
+    R13,
+    R14,
+    R15,
+    CS,
+    SS,
+    DS,
+    ES,
+    FS,
+    GS,
+    IDT_BASE,
+    IDT_LIMIT,
+    GDT_BASE,
+    GDT_LIMIT,
+    LDTR,
+    LDT_BASE,
+    LDT_LIMIT,
+    LDT_AR,
+    TR,
+    TSS_BASE,
+    TSS_LIMIT,
+    TSS_AR,
+    CR0,
+    CR1,
+    CR2,
+    CR3,
+    CR4,
+    DR0,
+    DR1,
+    DR2,
+    DR3,
+    DR4,
+    DR5,
+    DR6,
+    DR7,
+    TPR,
+    XCR0,
+    REGISTERS_MAX,
+}
+
+/// VMX cabability
+#[allow(non_camel_case_types)]
+#[derive(Clone, Debug)]
+#[repr(C)]
+pub enum VMXCap {
+    /// Pin-based VMX capabilities
+    PINBASED = 0,
+    /// Primary proc-based VMX capabilities
+    PROCBASED = 1,
+    /// Secondary proc-based VMX capabilities
+    PROCBASED2 = 2,
+    /// VM-entry VMX capabilities
+    ENTRY = 3,
+    /// VM-exit VMX capabilities
+    EXIT = 4,
+    /// VMX preemption timer frequency
+    PREEMPTION_TIMER = 32,
+}

--- a/xhype/xhype/src/hv/mod.rs
+++ b/xhype/xhype/src/hv/mod.rs
@@ -5,7 +5,7 @@ mod ffi;
 #[allow(non_camel_case_types)]
 #[derive(Clone)]
 #[repr(C)]
-pub enum x86Reg {
+pub enum X86Reg {
     RIP,
     RFLAGS,
     RAX,

--- a/xhype/xhype/src/lib.rs
+++ b/xhype/xhype/src/lib.rs
@@ -1,0 +1,3 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+
+mod hv;


### PR DESCRIPTION
Hello, 

This pull request contains the foreign function interfaces of Hypervisor.framework, obtained from [xhypervisor](https://crates.io/crates/xhypervisor). To be specific:
* hv/ffi.rs is from https://github.com/RWTH-OS/xhypervisor/blob/master/src/ffi.rs
* hv/mod.rs is from https://github.com/RWTH-OS/xhypervisor/blob/master/src/lib.rs

Besides, I fixed the parameter type of `value` in `hv_vcpu_write_msr` in `ffi.rs`, which should be `u64` instead of `*const u64`.

Changyuan