### PR TITLE
Wrap Hypervisor FFI into safe Rust interfaces

### DIFF
--- a/xhype/xhype/src/hv/ffi.rs
+++ b/xhype/xhype/src/hv/ffi.rs
@@ -94,12 +94,12 @@ extern "C" {
     /// of a vCPU
     pub fn hv_vcpu_read_register(
         vcpu: hv_vcpuid_t,
-        reg: super::x86Reg,
+        reg: super::X86Reg,
         value: *mut u64,
     ) -> hv_return_t;
 
     /// Sets the value of an architectural x86 register of a vCPU
-    pub fn hv_vcpu_write_register(vcpu: hv_vcpuid_t, reg: super::x86Reg, value: u64)
+    pub fn hv_vcpu_write_register(vcpu: hv_vcpuid_t, reg: super::X86Reg, value: u64)
         -> hv_return_t;
 }
 

--- a/xhype/xhype/src/hv/vmx.rs
+++ b/xhype/xhype/src/hv/vmx.rs
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
 
-// VMCS constants from Hypervisor/hv_arch_vmx.h
+//! VMCS constants from Hypervisor/hv_arch_vmx.h
 
 pub const VMX_BASIC_TRUE_CTLS: u64 = 1 << 55;
 

--- a/xhype/xhype/src/lib.rs
+++ b/xhype/xhype/src/lib.rs
@@ -3,7 +3,6 @@
 pub mod bios;
 pub mod consts;
 pub mod err;
-#[allow(dead_code)]
-mod hv;
+pub mod hv;
 pub mod linux;
 pub mod mach;


### PR DESCRIPTION
Use `cargo test -- --test-threads=1` to run unit tests to avoid `vm_create` being called simutaneously.