### PR TITLE
Rust interface for calling CPUID

### DIFF
--- a/xhype/xhype/Cargo.toml
+++ b/xhype/xhype/Cargo.toml
@@ -9,3 +9,7 @@ edition = "2018"
 build = "build.rs"
 
 [dependencies]
+
+
+[build-dependencies]
+cc = "1.0.46"

--- a/xhype/xhype/build.rs
+++ b/xhype/xhype/build.rs
@@ -1,5 +1,6 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
 
 fn main() {
+    cc::Build::new().file("c_src/cpuid.c").compile("cpuid");
     println!("cargo:rustc-link-lib=framework=Hypervisor");
 }

--- a/xhype/xhype/c_src/cpuid.c
+++ b/xhype/xhype/c_src/cpuid.c
@@ -1,0 +1,9 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+#include <stdint.h>
+
+void cpuid(uint32_t ieax, uint32_t iecx, uint32_t *eaxp, uint32_t *ebxp,
+           uint32_t *ecxp, uint32_t *edxp) {
+  asm volatile("cpuid"
+               : "=a"(*eaxp), "=b"(*ebxp), "=c"(*ecxp), "=d"(*edxp)
+               : "a"(ieax), "c"(iecx));
+}

--- a/xhype/xhype/src/cpuid.rs
+++ b/xhype/xhype/src/cpuid.rs
@@ -1,0 +1,26 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+extern "C" {
+    fn cpuid(ieax: u32, iecx: u32, eaxp: *mut u32, ebxp: *mut u32, ecxp: *mut u32, edxp: *mut u32);
+}
+
+pub fn do_cpuid(eax: u32, ecx: u32) -> (u32, u32, u32, u32) {
+    let mut o_eax = 0;
+    let mut o_ebx = 0;
+    let mut o_ecx = 0;
+    let mut o_edx = 0;
+    unsafe { cpuid(eax, ecx, &mut o_eax, &mut o_ebx, &mut o_ecx, &mut o_edx) }
+    (o_eax, o_ebx, o_ecx, o_edx)
+}
+
+#[cfg(test)]
+mod test {
+    use super::do_cpuid;
+    #[test]
+    fn do_cpuid_test() {
+        let (_, ebx, ecx, edx) = do_cpuid(0, 0);
+        // GenuineIntel
+        assert_eq!(ebx, 0x756e6547);
+        assert_eq!(ecx, 0x6c65746e);
+        assert_eq!(edx, 0x49656e69);
+    }
+}

--- a/xhype/xhype/src/lib.rs
+++ b/xhype/xhype/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod bios;
 pub mod consts;
+pub mod cpuid;
 pub mod err;
 pub mod hv;
 pub mod linux;


### PR DESCRIPTION
Macro `ams!` requires nightly rust. So we implement the interface in C and then wrap it into a rust function.