### PR TITLE
Implement the loop for running a vCPU and handling vm exits 

### DIFF
--- a/xhype/xhype/src/hv/mod.rs
+++ b/xhype/xhype/src/hv/mod.rs
@@ -29,6 +29,7 @@ This mod requires macOS (10.15) or newer.
 pub mod ffi;
 pub mod vmx;
 
+use crate::consts::msr::*;
 use crate::err::Error;
 use ffi::*;
 use vmx::*;
@@ -421,6 +422,21 @@ impl VCPU {
             unsafe { hv_vmx_vcpu_set_apic_address(self.id, address as u64) },
             "hv_vmx_vcpu_set_apic_address",
         )
+    }
+
+    pub fn enable_msrs(&self) -> Result<(), Error> {
+        self.enable_native_msr(MSR_STAR, true)?;
+        self.enable_native_msr(MSR_LSTAR, true)?;
+        self.enable_native_msr(MSR_CSTAR, true)?;
+        self.enable_native_msr(MSR_SYSCALL_MASK, true)?;
+        self.enable_native_msr(MSR_KERNEL_GS_BASE, true)?;
+        self.enable_native_msr(MSR_GS_BASE, true)?;
+        self.enable_native_msr(MSR_FS_BASE, true)?;
+        self.enable_native_msr(MSR_IA32_SYSENTER_CS, true)?;
+        self.enable_native_msr(MSR_IA32_SYSENTER_ESP, true)?;
+        self.enable_native_msr(MSR_IA32_SYSENTER_EIP, true)?;
+        self.enable_native_msr(MSR_IA32_TSC, true)?;
+        self.enable_native_msr(MSR_TSC_AUX, true)
     }
 }
 

--- a/xhype/xhype/src/hv/mod.rs
+++ b/xhype/xhype/src/hv/mod.rs
@@ -127,7 +127,7 @@ pub struct VCPU {
 
 /// x86 architectural register
 #[allow(non_camel_case_types)]
-#[derive(Clone)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 #[repr(C)]
 pub enum X86Reg {
     RIP,

--- a/xhype/xhype/src/vmexit.rs
+++ b/xhype/xhype/src/vmexit.rs
@@ -1,0 +1,43 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+
+use crate::err::Error;
+use crate::hv::vmx::*;
+use crate::{GuestThread, VCPU};
+#[allow(unused_imports)]
+use log::*;
+
+#[derive(Debug, Eq, PartialEq)]
+pub enum HandleResult {
+    Exit,
+    Resume,
+    Next,
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// VMX_REASON_EPT_VIOLATION
+////////////////////////////////////////////////////////////////////////////////
+
+pub fn ept_read(qual: u64) -> bool {
+    qual & 1 > 0
+}
+
+pub fn ept_write(qual: u64) -> bool {
+    qual & 0b10 > 0
+}
+
+pub fn ept_instr_fetch(qual: u64) -> bool {
+    qual & 0b100 > 0
+}
+
+pub fn ept_page_walk(qual: u64) -> bool {
+    qual & (1 << 7) > 0 && qual & (1 << 8) == 0
+}
+
+pub fn handle_ept_violation(
+    _vcpu: &VCPU,
+    _gth: &mut GuestThread,
+    _gpa: usize,
+) -> Result<HandleResult, Error> {
+    // we need to handle MMIOs. But for now we just resume the vm.
+    Ok(HandleResult::Resume)
+}


### PR DESCRIPTION
Currently we handle EPT violation by simply resuming the VM. This is because the Hypervisor Framework will not setup EPT table until a EPT violation happens. 

In the future we need to check the guest physical address and see if we need to do MMIO or just resume the VM.