### PR TITLE
destroy vm at the end of hv_mem_space_destroy_test()

### DIFF
--- a/xhype/xhype/src/hv/mod.rs
+++ b/xhype/xhype/src/hv/mod.rs
@@ -567,6 +567,8 @@ mod test {
             ret = hv_vm_space_destroy(space_id);
             // vcpu is destroyed, but the memory space still think itself occupied by the vcpu
             assert_eq!(ret, HV_BUSY);
+            ret = hv_vm_destroy();
+            assert_eq!(ret, HV_SUCCESS);
         }
     }
 }


### PR DESCRIPTION
One process can only call hv_vm_create() once before hv_vm_destroy() is called. So we have to destroy the vm  at the end of this test, otherwise other tests would fail, because they cannot call hv_vm_create().