### PR TITLE
Setup the interrupt system

### DIFF
--- a/xhype/xhype/src/consts/x86.rs
+++ b/xhype/xhype/src/consts/x86.rs
@@ -31,6 +31,7 @@ pub const X86_EFLAGS_ID: u64 = 0x00200000; /* CPUID detection flag */
 
 pub const FL_RSVD_1: u64 = 0x00000002; // These 1s must be 1, rflags |= this
 pub const FL_RSVD_0: u64 = 0x003f7fd7; // These 0s must be 0, rflags &= this
+pub const FL_IF: u64 = 1 << 9;
 
 /*
  * Basic CPU control in CR0

--- a/xhype/xhype/src/hv/ffi.rs
+++ b/xhype/xhype/src/hv/ffi.rs
@@ -72,6 +72,9 @@ extern "C" {
     /// Executes a vCPU
     pub fn hv_vcpu_run(vcpu: hv_vcpuid_t) -> hv_return_t;
 
+    /// Executes a vCPU until the given deadline. The timer deadline in mach absolute time units.
+    pub fn hv_vcpu_run_until(vcpu: hv_vcpuid_t, deadline: u64) -> hv_return_t;
+
     /// Forces an immediate VMEXIT of a set of vCPUs of the VM
     pub fn hv_vcpu_interrupt(vcpu: *const hv_vcpuid_t, vcpu_count: u32) -> hv_return_t;
 

--- a/xhype/xhype/src/hv/mod.rs
+++ b/xhype/xhype/src/hv/mod.rs
@@ -414,6 +414,13 @@ impl VCPU {
         check_ret(unsafe { hv_vcpu_run(self.id) }, "hv_vcpu_run")
     }
 
+    pub fn run_until(&self, deadline: u64) -> Result<(), Error> {
+        check_ret(
+            unsafe { hv_vcpu_run_until(self.id, deadline) },
+            "hv_vcpu_run_until",
+        )
+    }
+
     pub fn read_vmcs(&self, field: u32) -> Result<u64, Error> {
         let mut value = 0;
         match unsafe { hv_vmx_vcpu_read_vmcs(self.id, field, &mut value) } {

--- a/xhype/xhype/src/lib.rs
+++ b/xhype/xhype/src/lib.rs
@@ -71,7 +71,6 @@ pub struct VirtualMachine {
     // its bios tables, APIC pages, high memory, etc.
     // the format is: guest virtual address -> host memory block
     pub(crate) mem_maps: RwLock<HashMap<usize, MachVMBlock>>,
-    threads: Option<Vec<GuestThread>>,
     // serial ports
     pub(crate) com1: RwLock<Serial>,
     pub(crate) ioapic: Arc<RwLock<IoApic>>,
@@ -91,7 +90,6 @@ impl VirtualMachine {
             mem_space: RwLock::new(MemSpace::create()?),
             cores,
             mem_maps: RwLock::new(HashMap::new()),
-            threads: None,
             com1: RwLock::new(Serial::default()),
             pci_bus: Mutex::new(PciBus::new()),
             ioapic: ioapic.clone(),


### PR DESCRIPTION
1. Implement an local APIC timer by vmx preemption timer
2. Collect IRQs from IO APIC using the `channel` provided by Rust