### PR TITLE
Implement COM1 as a console

### DIFF
--- a/xhype/xhype/build.rs
+++ b/xhype/xhype/build.rs
@@ -4,6 +4,9 @@ fn main() {
     cc::Build::new().file("c_src/cpuid.c").compile("cpuid");
     cc::Build::new().file("c_src/utils.c").compile("utils");
     cc::Build::new().file("c_src/hlt.s").compile("hlt");
+    cc::Build::new()
+        .file("c_src/serial_c.c")
+        .compile("serial_c");
 
     println!("cargo:rustc-link-lib=framework=Hypervisor");
 }

--- a/xhype/xhype/c_src/serial_c.c
+++ b/xhype/xhype/c_src/serial_c.c
@@ -1,0 +1,14 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+
+#include <termios.h>
+#include <unistd.h>
+#include <stdlib.h>
+
+void make_stdin_raw_c() {
+    struct termios old;
+    tcgetattr(STDIN_FILENO, &old);
+    struct termios new = old;
+    cfmakeraw(&new);
+    new.c_cflag |= CLOCAL;
+    tcsetattr(STDIN_FILENO, TCSANOW, &new);
+}

--- a/xhype/xhype/src/lib.rs
+++ b/xhype/xhype/src/lib.rs
@@ -77,7 +77,7 @@ pub struct VirtualMachine {
     // the format is: guest virtual address -> host memory block
     pub(crate) mem_maps: RwLock<HashMap<usize, MachVMBlock>>,
     // serial ports
-    pub(crate) com1: RwLock<Serial>,
+    pub(crate) com1: Mutex<Serial>,
     pub(crate) ioapic: Arc<RwLock<IoApic>>,
     pub(crate) vcpu_ids: Arc<RwLock<Vec<u32>>>,
     pub(crate) rtc: RwLock<Rtc>,
@@ -96,7 +96,7 @@ impl VirtualMachine {
             mem_space: RwLock::new(MemSpace::create()?),
             cores,
             mem_maps: RwLock::new(HashMap::new()),
-            com1: RwLock::new(Serial::default()),
+            com1: Mutex::new(Serial::new(4, irq_sender.clone())),
             pci_bus: Mutex::new(PciBus::new()),
             ioapic: ioapic.clone(),
             vcpu_ids: vcpu_ids.clone(),

--- a/xhype/xhype/src/utils.rs
+++ b/xhype/xhype/src/utils.rs
@@ -13,6 +13,10 @@ pub fn round_down_4k(num: usize) -> usize {
     num & !0xfff
 }
 
+pub fn make_stdin_raw() {
+    unsafe { make_stdin_raw_c() }
+}
+
 pub fn get_tsc_frequency() -> u64 {
     let mut size = size_of::<u64>();
     let mut tsc_freq = 0;
@@ -53,6 +57,7 @@ extern "C" {
     );
     fn mach_absolute_time() -> u64;
     fn mach_timebase(numer: *mut u32, denom: *mut u32) -> bool;
+    fn make_stdin_raw_c();
 }
 
 #[cfg(test)]

--- a/xhype/xhype/src/vmexit.rs
+++ b/xhype/xhype/src/vmexit.rs
@@ -355,11 +355,11 @@ pub fn handle_io(vcpu: &VCPU, gth: &GuestThread) -> Result<HandleResult, Error> 
         }
         COM1_BASE..=COM1_MAX => {
             if qual.is_in() {
-                let v = gth.vm.com1.write().unwrap().read(port - COM1_BASE);
+                let v = gth.vm.com1.lock().unwrap().read(port - COM1_BASE);
                 vcpu.write_reg_16_low(X86Reg::RAX, v)?;
             } else {
                 let v = (rax & 0xff) as u8;
-                gth.vm.com1.write().unwrap().write(port - COM1_BASE, v);
+                gth.vm.com1.lock().unwrap().write(port - COM1_BASE, v);
             }
         }
         PCI_CONFIG_ADDR => {


### PR DESCRIPTION
COM1 now reads input from stdin and is capable to send interrupts to guest threads. 

Known issue: If a linux kernel is booted with `console=ttyS0`, once the kernel finishes initialization and is going to print its banner, it cannot get a notification that COM1 is ready to accept data. We need to type in some characters such that the kernel gets notified.  