### PR TITLE
Add options for unknown ports and MSRs

### DIFF
--- a/xhype/xhype/Cargo.toml
+++ b/xhype/xhype/Cargo.toml
@@ -12,6 +12,7 @@ build = "build.rs"
 log = "0.4"
 bitfield = "0.13.2"
 chrono = "0.4"
+rand = "0.7.3"
 
 
 [build-dependencies]


### PR DESCRIPTION
For each VirtualMachine, we could return all ones, or a random value, or inject a #GP if an unknown MSR is accessed. For unknown ports, we can also return all ones or a random value.

As default, we inject #GP for unknown MSRs and return all ones for unknown ports.