### PR TITLE
Implement virtio-mmio net device based on vmnet framework

### DIFF
--- a/xhype/xhype/build.rs
+++ b/xhype/xhype/build.rs
@@ -7,6 +7,11 @@ fn main() {
     cc::Build::new()
         .file("c_src/serial_c.c")
         .compile("serial_c");
+    cc::Build::new()
+        .file("c_src/vmnet.m")
+        .compile("virtio-vmnet");
 
     println!("cargo:rustc-link-lib=framework=Hypervisor");
+    println!("cargo:rustc-link-lib=framework=Cocoa");
+    println!("cargo:rustc-link-lib=framework=vmnet");
 }

--- a/xhype/xhype/c_src/vmnet.m
+++ b/xhype/xhype/c_src/vmnet.m
@@ -1,0 +1,87 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+
+#import <Foundation/Foundation.h>
+#import <vmnet/vmnet.h>
+#include <stdint.h>
+#include <sys/types.h>
+#include <sys/uio.h>
+#include <unistd.h>
+#include <pthread.h>
+
+#define MAC_STR_LENGTH 17
+
+NSMutableDictionary* start_semaphores  = nil;
+NSMutableDictionary* finish_semaphores = nil;
+pthread_rwlock_t lock = PTHREAD_RWLOCK_INITIALIZER;
+
+vmnet_return_t
+vmnet_read_blocking(interface_ref interface, struct vmpktdesc *packets, int *pktcnt) {
+    @autoreleasepool {
+        dispatch_semaphore_t start;
+        dispatch_semaphore_t finish;
+        
+        pthread_rwlock_rdlock(&lock);
+        NSString* ref_key = [NSString stringWithFormat:@"%p", interface];
+        start = [start_semaphores objectForKey:ref_key];
+        finish = [finish_semaphores objectForKey:ref_key];
+        pthread_rwlock_unlock(&lock);
+        
+        dispatch_wait(start, DISPATCH_TIME_FOREVER);
+        
+        vmnet_return_t ret = vmnet_read(interface, packets, pktcnt);
+        
+        dispatch_semaphore_signal(finish);
+        
+        return ret;
+    }
+}
+
+
+// This function is inspired by vmn_create() from
+// https://github.com/machyve/xhyve/blob/master/src/pci_virtio_net_vmnet.c
+uint32_t create_interface(interface_ref* ref_p, char* mac, uint16_t* mtu) {
+    @autoreleasepool {
+        pthread_rwlock_wrlock(&lock);
+        if (start_semaphores == nil) {
+            start_semaphores = [[NSMutableDictionary alloc] init];        }
+        if (finish_semaphores == nil) {
+            finish_semaphores = [[NSMutableDictionary alloc] init];
+        }
+        pthread_rwlock_unlock(&lock);
+        
+        xpc_object_t desc = xpc_dictionary_create(NULL, NULL, 0);
+        xpc_dictionary_set_uint64(desc, vmnet_operation_mode_key, VMNET_SHARED_MODE);
+        
+        dispatch_semaphore_t s = dispatch_semaphore_create(0);
+        __block vmnet_return_t ret;
+        interface_ref ref = vmnet_start_interface(desc, dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^(vmnet_return_t status, xpc_object_t  _Nullable interface_param) {
+            ret = status;
+            if (status == VMNET_SUCCESS) {
+                memcpy(mac, xpc_dictionary_get_string(interface_param, vmnet_mac_address_key), MAC_STR_LENGTH);
+                *mtu = (uint16_t)xpc_dictionary_get_uint64(interface_param, vmnet_mtu_key);
+            }
+            dispatch_semaphore_signal(s);
+        });
+        dispatch_semaphore_wait(s, DISPATCH_TIME_FOREVER);
+        if (ref == NULL || ret != VMNET_SUCCESS) {
+            return -1;
+        }
+        
+        dispatch_semaphore_t start = dispatch_semaphore_create(0);
+        dispatch_semaphore_t finish = dispatch_semaphore_create(0);
+        
+        pthread_rwlock_wrlock(&lock);
+        NSString* ref_key = [NSString stringWithFormat:@"%p", ref];
+        [start_semaphores setValue:start forKey:ref_key];
+        [finish_semaphores setValue:finish forKey:ref_key];
+        pthread_rwlock_unlock(&lock);
+        
+        vmnet_interface_set_event_callback(ref, VMNET_INTERFACE_PACKETS_AVAILABLE, dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^(__attribute__((unused)) interface_event_t event_mask, __attribute__((unused)) xpc_object_t  _Nonnull event) {
+            dispatch_semaphore_signal(start);
+            dispatch_semaphore_wait(finish, DISPATCH_TIME_FOREVER);
+        });
+        
+        *ref_p = ref;
+        return 0;
+    }
+}

--- a/xhype/xhype/examples/xhype_linux.rs
+++ b/xhype/xhype/examples/xhype_linux.rs
@@ -55,6 +55,7 @@ use std::fs::File;
 use std::sync::Arc;
 use xhype::consts::*;
 use xhype::err::Error;
+use xhype::virtio::VirtioDevice;
 use xhype::{linux, MsrPolicy, PolicyList, PortPolicy, VMManager};
 
 fn boot_linux() {
@@ -108,6 +109,12 @@ fn boot_linux() {
     let rd_path = env::var("RD_PATH").ok();
     let cmd_line = env::var("CMD_Line").unwrap_or("auto".to_string());
     let mut vm = vmm.create_vm(1, low_mem_size).unwrap();
+    vm.add_virtio_mmio_device(VirtioDevice::new_vmnet(
+        "virtio-vmnet".to_string(),
+        0,
+        vm.irq_sender.clone(),
+        vm.gpa2hva.clone(),
+    ));
     vm.port_list = port_list;
     vm.port_policy = port_policy;
     vm.msr_list = msr_list;

--- a/xhype/xhype/src/lib.rs
+++ b/xhype/xhype/src/lib.rs
@@ -13,6 +13,7 @@ pub mod pci;
 pub mod rtc;
 pub mod serial;
 pub mod utils;
+pub mod virtio;
 pub mod vmexit;
 pub mod vthread;
 

--- a/xhype/xhype/src/virtio/mmio.rs
+++ b/xhype/xhype/src/virtio/mmio.rs
@@ -1,0 +1,466 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+
+use super::consts::*;
+use super::virtq::*;
+use super::{AddressConverter, IrqSender, TaskReceiver};
+use super::{VirtioDevice, VirtqReceiver};
+use crate::{err::Error, GuestThread, VCPU};
+#[allow(unused_imports)]
+use log::*;
+use std::sync::{Arc, RwLock};
+
+// The implementation is based on https://github.com/akaros/akaros/blob/master/user/vmm/virtio_mmio.c
+
+/*
+ * Control registers
+ */
+
+/* Magic value ("virt" string) - Read Only */
+pub const VIRTIO_MMIO_MAGIC_VALUE: usize = 0x000;
+
+/* Virtio device version - Read Only */
+pub const VIRTIO_MMIO_VERSION: usize = 0x004;
+
+/* Virtio device ID - Read Only */
+pub const VIRTIO_MMIO_DEVICE_ID: usize = 0x008;
+
+/* Virtio vendor ID - Read Only */
+pub const VIRTIO_MMIO_VENDOR_ID: usize = 0x00c;
+
+/* Bitmask of the features supported by the device (host)
+ * (32 bits per set) - Read Only */
+pub const VIRTIO_MMIO_DEVICE_FEATURES: usize = 0x010;
+
+/* Device (host) features set selector - Write Only */
+pub const VIRTIO_MMIO_DEVICE_FEATURES_SEL: usize = 0x014;
+
+/* Bitmask of features activated by the driver (guest)
+ * (32 bits per set) - Write Only */
+pub const VIRTIO_MMIO_DRIVER_FEATURES: usize = 0x020;
+
+/* Activated features set selector - Write Only */
+pub const VIRTIO_MMIO_DRIVER_FEATURES_SEL: usize = 0x024;
+
+/* Guest's memory page size in bytes - Write Only */
+#[cfg(feature = "virtio_mmio_legacy")]
+pub const VIRTIO_MMIO_GUEST_PAGE_SIZE: usize = 0x028;
+
+/* Queue selector - Write Only */
+pub const VIRTIO_MMIO_QUEUE_SEL: usize = 0x030;
+
+/* Maximum size of the currently selected queue - Read Only */
+pub const VIRTIO_MMIO_QUEUE_NUM_MAX: usize = 0x034;
+
+/* Queue size for the currently selected queue - Write Only */
+pub const VIRTIO_MMIO_QUEUE_NUM: usize = 0x038;
+
+/* Used Ring alignment for the currently selected queue - Write Only */
+#[cfg(feature = "virtio_mmio_legacy")]
+pub const VIRTIO_MMIO_QUEUE_ALIGN: usize = 0x03c;
+
+/* Guest's PFN for the currently selected queue - Read Write */
+#[cfg(feature = "virtio_mmio_legacy")]
+pub const VIRTIO_MMIO_QUEUE_PFN: usize = 0x040;
+
+/* Ready bit for the currently selected queue - Read Write */
+pub const VIRTIO_MMIO_QUEUE_READY: usize = 0x044;
+
+/* Queue notifier - Write Only */
+pub const VIRTIO_MMIO_QUEUE_NOTIFY: usize = 0x050;
+
+/* Interrupt status - Read Only */
+pub const VIRTIO_MMIO_INTERRUPT_STATUS: usize = 0x060;
+
+/* Interrupt acknowledge - Write Only */
+pub const VIRTIO_MMIO_INTERRUPT_ACK: usize = 0x064;
+
+/* Device status register - Read Write */
+pub const VIRTIO_MMIO_STATUS: usize = 0x070;
+
+/* Selected queue's Descriptor Table address, 64 bits in two halves */
+pub const VIRTIO_MMIO_QUEUE_DESC_LOW: usize = 0x080;
+pub const VIRTIO_MMIO_QUEUE_DESC_HIGH: usize = 0x084;
+
+/* Selected queue's Available Ring address, 64 bits in two halves */
+pub const VIRTIO_MMIO_QUEUE_AVAIL_LOW: usize = 0x090;
+pub const VIRTIO_MMIO_QUEUE_AVAIL_HIGH: usize = 0x094;
+
+/* Selected queue's Used Ring address, 64 bits in two halves */
+pub const VIRTIO_MMIO_QUEUE_USED_LOW: usize = 0x0a0;
+pub const VIRTIO_MMIO_QUEUE_USED_HIGH: usize = 0x0a4;
+
+/* Configuration atomicity value */
+pub const VIRTIO_MMIO_CONFIG_GENERATION: usize = 0x0fc;
+
+/* The config space is defined by each driver as
+ * the per-driver configuration space - Read Write */
+pub const VIRTIO_MMIO_CONFIG: usize = 0x100;
+
+pub const VIRTIO_MMIO_INT_VRING: u32 = 1 << 0;
+pub const VIRTIO_MMIO_INT_CONFIG: u32 = 1 << 1;
+
+pub const VIRT_MAGIC: u32 = 0x74726976; /* 'virt' */
+
+pub const VIRT_MMIO_VERSION: u32 = 0x2;
+
+pub const VIRT_MMIO_VENDOR: u32 = 0x52414B41; /* 'AKAR' */
+
+pub struct VirtioMmioDev {
+    pub(crate) addr: usize,
+    pub(crate) dev: VirtioDevice,
+}
+
+impl VirtioMmioDev {
+    pub fn reset(&mut self) {
+        self.dev.dri_feat = 0;
+        self.dev.status = 0;
+        *self.dev.isr.write().unwrap() = 0;
+        for vq in self.dev.vqs.iter_mut() {
+            vq.qready = 0;
+        }
+        self.dev.cfg.reset();
+    }
+
+    pub fn selected_vq(&mut self) -> Option<&mut VirtqManager> {
+        if (self.dev.qsel as usize) < self.dev.vqs.len() {
+            let vq = &mut self.dev.vqs[self.dev.qsel as usize];
+            if vq.qready != 0 {
+                error!(
+                    "guest accesses virtq {}, which has nonzero QueueReady.",
+                    vq.name
+                );
+                None
+            } else {
+                Some(vq)
+            }
+        } else {
+            error!(
+                "guest accesses dev {}'s virtq with an invalid qsel {}",
+                self.dev.name, self.dev.qsel
+            );
+            None
+        }
+    }
+}
+
+pub fn virtq_server<F>(
+    task_rx: TaskReceiver,
+    virtq_rx: VirtqReceiver,
+    irq: u32,
+    irq_tx: IrqSender,
+    isr: Arc<RwLock<u32>>,
+    gpa2hva: &AddressConverter,
+    handler: F,
+) where
+    F: Fn(&Virtq<usize>, u16, &AddressConverter) -> u32,
+{
+    for virtq in virtq_rx.iter() {
+        let virtq = virtq.to_hva(|gpa| gpa2hva(gpa));
+        let mut current_index = 0;
+        for t in task_rx.iter() {
+            if t.is_none() {
+                break;
+            }
+            let avail_index = virtq.avail_index();
+            while current_index < avail_index {
+                let length_write = handler(&virtq, current_index, gpa2hva);
+                virtq.push_used(virtq.read_avail(current_index), length_write);
+                current_index += 1;
+                let avail_flag = virtq.avail_flags();
+                if avail_flag & VIRTQ_AVAIL_F_NO_INTERRUPT == 0 {
+                    *isr.write().unwrap() |= VIRTIO_MMIO_INT_VRING;
+                    irq_tx.send(irq).unwrap();
+                }
+            }
+        }
+    }
+}
+
+fn virtio_mmio_read(mmio_dev: &VirtioMmioDev, gpa: usize, size: u8) -> u32 {
+    let offset = gpa - mmio_dev.addr as usize;
+
+    if offset >= VIRTIO_MMIO_CONFIG {
+        let offset = offset - VIRTIO_MMIO_CONFIG;
+        let ret = if let Some(val) = mmio_dev.dev.cfg.read(offset, size) {
+            val
+        } else {
+            error!(
+                "the driver reads config of device {} with invalid size or offset: ({}, 0x{:x})",
+                mmio_dev.dev.name, size, offset
+            );
+            0
+        };
+        return ret;
+    }
+
+    if size != 4 || offset % 4 != 0 {
+        error!(
+            "The driver must only use 32 bit wide and aligned reads for \
+        reading the control registers on the MMIO transport. See \
+        virtio-v1.0-cs04 4.2.2.2 MMIO Device Register Layout."
+        );
+    }
+
+    match offset {
+        VIRTIO_MMIO_MAGIC_VALUE => VIRT_MAGIC,
+
+        VIRTIO_MMIO_VERSION => VIRT_MMIO_VERSION,
+
+        VIRTIO_MMIO_DEVICE_ID => mmio_dev.dev.dev_id as u32,
+
+        // Virtio Subsystem Vendor ID
+        VIRTIO_MMIO_VENDOR_ID => VIRT_MMIO_VENDOR,
+
+        // Flags representing features the device supports
+        VIRTIO_MMIO_DEVICE_FEATURES => {
+            if mmio_dev.dev.status & VIRTIO_CONFIG_S_DRIVER == 0 {
+                error!(
+                    "Attempt to read device features before setting the \
+                DRIVER status bit. See virtio-v1.0-cs04 s3.1.1 Device Initialization"
+                );
+            }
+            (if mmio_dev.dev.dev_feat_sel > 0 {
+                mmio_dev.dev.dev_feat >> 32 // high 32 bits requested
+            } else {
+                mmio_dev.dev.dev_feat & 0xffffffff // low 32 bits requested
+            }) as u32
+        }
+
+        VIRTIO_MMIO_QUEUE_NUM_MAX => {
+            if mmio_dev.dev.qsel as usize >= mmio_dev.dev.vqs.len() {
+                0
+            } else {
+                mmio_dev.dev.vqs[mmio_dev.dev.qsel as usize].qnum_max
+            }
+        }
+
+        VIRTIO_MMIO_QUEUE_READY => {
+            if mmio_dev.dev.qsel as usize >= mmio_dev.dev.vqs.len() {
+                0
+            } else {
+                mmio_dev.dev.vqs[mmio_dev.dev.qsel as usize].qready
+            }
+        }
+
+        VIRTIO_MMIO_INTERRUPT_STATUS => *mmio_dev.dev.isr.read().unwrap(),
+
+        VIRTIO_MMIO_STATUS => mmio_dev.dev.status as u32,
+
+        VIRTIO_MMIO_CONFIG_GENERATION => mmio_dev.dev.cfg_gen,
+
+        _ => {
+            error!(
+                "driver attempts to read write-only or invalid register offset {:x} of device {}",
+                offset, mmio_dev.dev.name
+            );
+            0
+        }
+    }
+}
+
+fn virtio_mmio_write(mmio_dev: &mut VirtioMmioDev, gpa: usize, size: u8, value: u32) {
+    let offset = gpa - mmio_dev.addr as usize;
+
+    if offset >= VIRTIO_MMIO_CONFIG {
+        let offset = offset - VIRTIO_MMIO_CONFIG;
+        if mmio_dev.dev.cfg.write(offset, size, value).is_none() {
+            error!(
+                "the driver writes config of device {} with invalid size or offset: ({}, 0x{:x})",
+                mmio_dev.dev.name, size, offset
+            );
+        }
+        return;
+    }
+
+    if size != 4 || offset % 4 != 0 {
+        error!(
+            "The driver must only use 32 bit wide and aligned reads for \
+        reading the control registers on the MMIO transport. See \
+        virtio-v1.0-cs04 4.2.2.2 MMIO Device Register Layout."
+        );
+    }
+
+    match offset {
+        VIRTIO_MMIO_DEVICE_FEATURES_SEL => mmio_dev.dev.dev_feat_sel = value,
+
+        VIRTIO_MMIO_DRIVER_FEATURES => {
+            if mmio_dev.dev.status & VIRTIO_CONFIG_S_FEATURES_OK > 0 {
+                error!(
+                    "The driver is not allowed to activate new features after \
+                setting FEATURES_OK"
+                );
+            } else if mmio_dev.dev.dri_feat_sel > 0 {
+                mmio_dev.dev.dri_feat &= 0xffffffff;
+                mmio_dev.dev.dri_feat |= (value as u64) << 32;
+            } else {
+                mmio_dev.dev.dri_feat &= 0xffffffffu64 << 32;
+                mmio_dev.dev.dri_feat |= value as u64;
+            }
+        }
+
+        VIRTIO_MMIO_DRIVER_FEATURES_SEL => mmio_dev.dev.dri_feat_sel = value,
+
+        VIRTIO_MMIO_QUEUE_SEL => mmio_dev.dev.qsel = value,
+
+        VIRTIO_MMIO_QUEUE_NUM => {
+            let qsel = mmio_dev.dev.qsel as usize;
+            if qsel < mmio_dev.dev.vqs.len() {
+                let vq = &mut mmio_dev.dev.vqs[qsel];
+                if value <= vq.qnum_max {
+                    vq.virtq.num = value;
+                } else {
+                    error!(
+                        "write a value to QueueNum which is greater than \
+                    QueueNumMax"
+                    );
+                }
+            } else {
+                error!("qsel has an invalid value. qsel >= vqs.len()");
+            }
+        }
+
+        VIRTIO_MMIO_QUEUE_READY => {
+            let qsel = mmio_dev.dev.qsel as usize;
+            if qsel < mmio_dev.dev.vqs.len() {
+                let vq = &mut mmio_dev.dev.vqs[qsel];
+                if vq.qready == 0x0 && value == 0x1 {
+                    vq.virtq_sender.send(vq.virtq.clone()).unwrap();
+                } else if vq.qready == 0x1 && value == 0x0 {
+                    // send a index None to indicate that this virtq is not
+                    // available any more
+                    vq.task_sender.send(None).unwrap();
+                }
+                vq.qready = value;
+            } else {
+                error!("qsel has an invalid value. qsel >= vqs.len()");
+            }
+        }
+
+        VIRTIO_MMIO_QUEUE_NOTIFY => {
+            let q_index = value as usize;
+            if mmio_dev.dev.status & VIRTIO_CONFIG_S_DRIVER_OK == 0 {
+                error!(
+                    "{} notify device before DRIVER_OK is set",
+                    mmio_dev.dev.name
+                );
+            } else if q_index < mmio_dev.dev.vqs.len() {
+                let vq = &mmio_dev.dev.vqs[q_index];
+                vq.task_sender.send(Some(())).unwrap();
+            }
+        }
+
+        VIRTIO_MMIO_INTERRUPT_ACK => {
+            if value & !0x3 > 0 {
+                error!(
+                    "{} set undefined bits in InterruptAck register, value = 0x{:x}",
+                    mmio_dev.dev.name, value
+                );
+            }
+            *mmio_dev.dev.isr.write().unwrap() &= !value;
+        }
+
+        VIRTIO_MMIO_STATUS => {
+            let mut value = value as u8;
+            if value == 0 {
+                mmio_dev.reset();
+            } else if mmio_dev.dev.status & !value != 0 {
+                error!("The driver must not clear any device status bits, except as a result of resetting the device.")
+            } else if mmio_dev.dev.status & VIRTIO_CONFIG_S_FAILED != 0 && mmio_dev.dev.status != value {
+                error!("The driver must reset the device after setting the FAILED status bit, before attempting to re-initialize the device.");
+            } else {
+                let dev = &mmio_dev.dev;
+                if value & VIRTIO_CONFIG_S_ACKNOWLEDGE > 0 {
+                    if value & VIRTIO_CONFIG_S_DRIVER > 0 {
+                        if value & VIRTIO_CONFIG_S_FEATURES_OK > 0 {
+                            if mmio_dev.dev.status & VIRTIO_CONFIG_S_FEATURES_OK > 0 {
+                                if value & VIRTIO_CONFIG_S_DRIVER_OK > 0 {
+                                    info!("the device {} is alive", mmio_dev.dev.name);
+                                } else {
+                                    warn!("feature bits are verified but driver is not ok");
+                                }
+                            } else {
+                                if let Err(s) = mmio_dev.dev.verify_feat() {
+                                    error!("feature bits verification failed: {}, dev: {}", s, dev.name);
+                                    value &= !VIRTIO_CONFIG_S_FEATURES_OK;
+                                } else {
+                                    info!("feature bits verification succeeded. dev: {}", dev.name);
+                                }
+                                if value & VIRTIO_CONFIG_S_DRIVER_OK != 0 {
+                                    error!("the driver cannot set feature_ok and driver_ok at the same time");
+                                    value &= !VIRTIO_CONFIG_S_DRIVER_OK;
+                                } else {
+                                    info!("the driver will re-verify feature-ok bit of dev {} is set.", dev.name);
+                                }
+                            }
+                        } else {
+                            info!("the driver is supposed to read {}'s feature bits later", mmio_dev.dev.name);
+                        }
+                    } else {
+                        info!(
+                            "the driver does not know how to drive {} for now",
+                            mmio_dev.dev.name
+                        );
+                    }
+                } else {
+                    warn!(
+                        "The driver ignored the device, {}",
+                        mmio_dev.dev.name
+                    );
+                }
+            }
+            mmio_dev.dev.status = value;
+            info!("dev {} status = {:b}", mmio_dev.dev.name, value);
+        }
+
+        VIRTIO_MMIO_QUEUE_DESC_LOW => {
+            if let Some(vq) = mmio_dev.selected_vq() {
+                set_u64_low(&mut vq.virtq.desc, value);
+            }
+        }
+
+        VIRTIO_MMIO_QUEUE_DESC_HIGH => {
+            if let Some(vq) = mmio_dev.selected_vq() {
+                set_u64_high(&mut vq.virtq.desc, value);
+            }
+        }
+
+        VIRTIO_MMIO_QUEUE_AVAIL_LOW => {
+            if let Some(vq) = mmio_dev.selected_vq() {
+                set_u64_low(&mut vq.virtq.avail, value);
+            }
+        }
+
+        VIRTIO_MMIO_QUEUE_AVAIL_HIGH => {
+            if let Some(vq) = mmio_dev.selected_vq() {
+                set_u64_high(&mut vq.virtq.avail, value);
+            }
+        }
+
+        VIRTIO_MMIO_QUEUE_USED_LOW => {
+            if let Some(vq) = mmio_dev.selected_vq() {
+                set_u64_low(&mut vq.virtq.used, value);
+            }
+        }
+
+        VIRTIO_MMIO_QUEUE_USED_HIGH => {
+            if let Some(vq) = mmio_dev.selected_vq() {
+                set_u64_high(&mut vq.virtq.used, value);
+            }
+        }
+
+        _ => error!(
+            "driver attempts to write 0x{:x} to read-only or invalid register offset {:x} of device {}",
+            value, offset, mmio_dev.dev.name
+        ),
+    }
+}
+
+fn set_u64_low(num: &mut u64, value: u32) {
+    *num &= !0xffffffff;
+    *num |= value as u64;
+}
+
+fn set_u64_high(num: &mut u64, value: u32) {
+    *num &= 0xffffffff;
+    *num |= (value as u64) << 32;
+}

--- a/xhype/xhype/src/virtio/mod.rs
+++ b/xhype/xhype/src/virtio/mod.rs
@@ -1,0 +1,89 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+
+pub mod virtq;
+
+use crate::AddressConverter;
+use crossbeam_channel::unbounded as channel;
+use crossbeam_channel::{Receiver, Sender};
+use std::sync::{Arc, RwLock};
+use virtq::*;
+
+type TaskSender = Sender<Option<()>>;
+type TaskReceiver = Receiver<Option<()>>;
+type VirtqSender = Sender<Virtq<u64>>;
+type VirtqReceiver = Receiver<Virtq<u64>>;
+type IrqSender = Sender<u32>;
+
+pub mod consts {
+    /* We have seen device and processed generic fields (VIRTIO_CONFIG_F_VIRTIO) */
+    pub const VIRTIO_CONFIG_S_ACKNOWLEDGE: u8 = 1;
+    /* We have found a driver for the device. */
+    pub const VIRTIO_CONFIG_S_DRIVER: u8 = 2;
+    /* Driver has used its parts of the config, and is happy */
+    pub const VIRTIO_CONFIG_S_DRIVER_OK: u8 = 4;
+    /* Driver has finished configuring features */
+    pub const VIRTIO_CONFIG_S_FEATURES_OK: u8 = 8;
+    /* Device entered invalid state, driver must reset it */
+    pub const VIRTIO_CONFIG_S_NEEDS_RESET: u8 = 0x40;
+    /* We've given up on this device. */
+    pub const VIRTIO_CONFIG_S_FAILED: u8 = 0x80;
+    /* v1.0 compliant. */
+    pub const VIRTIO_F_VERSION_1: u8 = 32;
+}
+
+// virtio-v1.0-cs04 s4 Device types
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VirtioId {
+    Reserved = 0,
+    Net = 1,
+    Block = 2,
+    Console = 3,
+    Entropy = 4,
+    BalloonTraditional = 5,
+    IoMemory = 6,
+    RpMsg = 7,
+    ScsiHost = 8,
+    Transport9P = 9, // 9P transport
+    Mac80211Wlan = 10,
+    RProcSerial = 11,
+    Caif = 12,
+    Balloon = 13,
+    GPU = 16,
+    Timer = 17,
+    Input = 18,
+}
+
+pub trait VirtioDevCfg {
+    fn reset(&mut self);
+    fn generation(&self) -> u32;
+    fn read(&self, offset: usize, size: u8) -> Option<u32>;
+    fn write(&mut self, offset: usize, size: u8, value: u32) -> Option<()>;
+}
+
+pub struct VirtioDevice {
+    name: String,
+    dev_id: VirtioId,
+    dev_feat: u64,
+    dri_feat: u64,
+    dev_feat_sel: u32,
+    dri_feat_sel: u32,
+    qsel: u32,
+    isr: Arc<RwLock<u32>>, // interrupt status
+    status: u8,
+    cfg_gen: u32,
+    cfg: Box<dyn VirtioDevCfg + Send + Sync + 'static>,
+    vqs: Vec<VirtqManager>,
+    pub(crate) irq: u32,
+}
+
+impl VirtioDevice {
+    pub fn verify_feat(&self) -> Result<(), &'static str> {
+        if self.dri_feat & (1 << consts::VIRTIO_F_VERSION_1) == 0 {
+            return Err("A driver must accept the VIRTIO_F_VERSION_1 feature bit");
+        }
+        if self.dri_feat & !self.dev_feat != 0 {
+            return Err("driver activated features that are not supported by the device");
+        }
+        Ok(())
+    }
+}

--- a/xhype/xhype/src/virtio/mod.rs
+++ b/xhype/xhype/src/virtio/mod.rs
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
 
 pub mod mmio;
+pub mod net;
 pub mod virtq;
 
 use crate::AddressConverter;

--- a/xhype/xhype/src/virtio/mod.rs
+++ b/xhype/xhype/src/virtio/mod.rs
@@ -1,5 +1,6 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
 
+pub mod mmio;
 pub mod virtq;
 
 use crate::AddressConverter;

--- a/xhype/xhype/src/virtio/net.rs
+++ b/xhype/xhype/src/virtio/net.rs
@@ -1,0 +1,293 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+
+use super::consts::*;
+use super::mmio::{virtq_server, VirtioMmioDev};
+use super::virtq::*;
+use super::{AddressConverter, Sender, VirtioDevCfg, VirtioDevice, VirtioId};
+#[allow(unused_imports)]
+use log::*;
+use std::io::IoSliceMut;
+use std::slice;
+use std::sync::{Arc, RwLock};
+
+pub const VIRTIO_HEADER_SIZE: usize = 12;
+
+pub const VIRTIO_NET_F_CSUM: u64 = 0; /* Host handles pkts w/ partial csum */
+pub const VIRTIO_NET_F_GUEST_CSUM: u64 = 1; /* Guest handles pkts w/ partial csum */
+pub const VIRTIO_NET_F_CTRL_GUEST_OFFLOADS: u64 = 2; /* Dynamic offload configuration. */
+pub const VIRTIO_NET_F_MTU: u64 = 3;
+pub const VIRTIO_NET_F_MAC: u64 = 5; /* Host has given MAC address. */
+pub const VIRTIO_NET_F_GUEST_TSO4: u64 = 7; /* Guest can handle TSOv4 in. */
+pub const VIRTIO_NET_F_GUEST_TSO6: u64 = 8; /* Guest can handle TSOv6 in. */
+pub const VIRTIO_NET_F_GUEST_ECN: u64 = 9; /* Guest can handle TSO[6] w/ ECN in. */
+pub const VIRTIO_NET_F_GUEST_UFO: u64 = 10; /* Guest can handle UFO in. */
+pub const VIRTIO_NET_F_HOST_TSO4: u64 = 11; /* Host can handle TSOv4 in. */
+pub const VIRTIO_NET_F_HOST_TSO6: u64 = 12; /* Host can handle TSOv6 in. */
+pub const VIRTIO_NET_F_HOST_ECN: u64 = 13; /* Host can handle TSO[6] w/ ECN in. */
+pub const VIRTIO_NET_F_HOST_UFO: u64 = 14; /* Host can handle UFO in. */
+pub const VIRTIO_NET_F_MRG_RXBUF: u64 = 15; /* Host can merge receive buffers. */
+pub const VIRTIO_NET_F_STATUS: u64 = 16; /* virtio_net_config.status available */
+pub const VIRTIO_NET_F_CTRL_VQ: u64 = 17; /* Control channel available */
+pub const VIRTIO_NET_F_CTRL_RX: u64 = 18; /* Control channel RX mode support */
+pub const VIRTIO_NET_F_CTRL_VLAN: u64 = 19; /* Control channel VLAN filtering */
+pub const VIRTIO_NET_F_CTRL_RX_EXTRA: u64 = 20; /* Extra RX mode control support */
+pub const VIRTIO_NET_F_GUEST_ANNOUNCE: u64 = 21; /* Guest can announce device on the network */
+
+pub const VMNET_SUCCESS: u32 = 1000;
+
+#[repr(C)]
+struct VmPktDesc<'a> {
+    vm_pkt_size: usize,
+    vm_pkt_iov: *mut IoSliceMut<'a>,
+    vm_pkt_iovcnt: u32,
+    vm_flags: u32,
+}
+
+extern "C" {
+    fn vmnet_read_blocking(interface: usize, packets: *mut VmPktDesc, pktcnt: *mut u32) -> u32;
+    fn vmnet_write(interface: usize, packets: *const VmPktDesc, pktcnt: *mut u32) -> u32;
+    fn create_interface(interface: *mut usize, mac: *mut u8, mtu: *mut u16) -> u32;
+}
+
+fn net_rx_handler(
+    virtq: &Virtq<usize>,
+    index: u16,
+    gpa2hva: &AddressConverter,
+    interface: usize,
+) -> u32 {
+    let (readable, writable) = virtq.get_avail(index, |gpa| gpa2hva(gpa));
+    debug_assert_eq!(readable.len(), 0);
+    drop(readable);
+    let mut trim_length = VIRTIO_HEADER_SIZE;
+    let mut iov = Vec::with_capacity(writable.len());
+    let mut total_size = 0;
+    for (mut addr, mut len) in writable.iter() {
+        if trim_length > 0 {
+            if len > trim_length {
+                len -= trim_length;
+                addr += trim_length;
+                trim_length = 0;
+            } else {
+                trim_length -= len;
+                continue;
+            }
+        }
+        total_size += len;
+        let io_slice = unsafe { slice::from_raw_parts_mut(addr as *mut u8, len) };
+        iov.push(IoSliceMut::new(io_slice));
+    }
+    let mut vmpktdesc = VmPktDesc {
+        vm_flags: 0,
+        vm_pkt_iovcnt: iov.len() as u32,
+        vm_pkt_size: total_size,
+        vm_pkt_iov: iov.as_mut_ptr(),
+    };
+    let mut pkt_count = 1;
+    let ret = unsafe { vmnet_read_blocking(interface, &mut vmpktdesc, &mut pkt_count) };
+    if ret == VMNET_SUCCESS && pkt_count == 1 {
+        info!("net_rx_srv, get {} bytes", vmpktdesc.vm_pkt_size);
+        let (addr, _) = writable[0];
+        let first_buffer = unsafe { slice::from_raw_parts_mut(addr as *mut u16, 8) };
+        for i in 0..5 {
+            first_buffer[i] = 0;
+        }
+        first_buffer[5] = 1;
+        let content = format!("{:04x?}", first_buffer);
+        error!("rx header {}", content);
+        (vmpktdesc.vm_pkt_size + VIRTIO_HEADER_SIZE) as u32
+    } else {
+        error!("vmnet_read() returns {}", ret);
+        0
+    }
+}
+
+fn net_rx_srv(iref: usize) -> VirtioVqSrv {
+    Box::new(move |task_rx, virtq_rx, irq, irq_tx, isr, gpa2hva| {
+        virtq_server(
+            task_rx,
+            virtq_rx,
+            irq,
+            irq_tx,
+            isr,
+            &gpa2hva,
+            |virtq: &Virtq<usize>, index: u16, converter| {
+                net_rx_handler(virtq, index, converter, iref)
+            },
+        );
+    })
+}
+
+fn net_tx_handler(
+    virtq: &Virtq<usize>,
+    index: u16,
+    gpa2hva: &AddressConverter,
+    interface: usize,
+) -> u32 {
+    let (readable, writable) = virtq.get_avail(index, |gpa| gpa2hva(gpa));
+    debug_assert_eq!(writable.len(), 0);
+    drop(writable);
+    let mut trim_length = VIRTIO_HEADER_SIZE;
+    let mut iov = Vec::with_capacity(readable.len());
+    let mut total_size = 0;
+    for (mut addr, mut len) in readable.into_iter() {
+        if trim_length > 0 {
+            if len > trim_length {
+                len -= trim_length;
+                addr += trim_length;
+                trim_length = 0;
+            } else {
+                trim_length -= len;
+                continue;
+            }
+        }
+        total_size += len;
+        let io_slice = unsafe { slice::from_raw_parts_mut(addr as *mut u8, len) };
+
+        iov.push(IoSliceMut::new(io_slice));
+    }
+    let vmpktdesc = VmPktDesc {
+        vm_flags: 0,
+        vm_pkt_iovcnt: iov.len() as u32,
+        vm_pkt_size: total_size,
+        vm_pkt_iov: iov.as_mut_ptr(),
+    };
+    let mut pkt_count = 1;
+    let ret = unsafe { vmnet_write(interface, &vmpktdesc, &mut pkt_count) };
+    if ret == VMNET_SUCCESS && pkt_count == 1 {
+        info!("net_tx_srv, write {} bytes", vmpktdesc.vm_pkt_size);
+    } else {
+        error!("vmnet_write returns {}", ret);
+    }
+    0
+}
+
+fn net_tx_srv(interface: usize) -> VirtioVqSrv {
+    Box::new(move |task_rx, virtq_rx, irq, irq_tx, isr, gpa2hva| {
+        virtq_server(
+            task_rx,
+            virtq_rx,
+            irq,
+            irq_tx,
+            isr,
+            &gpa2hva,
+            |virtq: &Virtq<usize>, index: u16, converter| {
+                net_tx_handler(virtq, index, converter, interface)
+            },
+        );
+    })
+}
+
+pub struct VirtioNetCfg {
+    pub mac: [u8; 6],
+    pub status: u16,
+    pub max_virtqueue_pairs: u16,
+    pub mtu: u16,
+    pub gen: u32,
+}
+
+impl VirtioDevCfg for VirtioNetCfg {
+    fn write(&mut self, _offset: usize, _size: u8, _value: u32) -> Option<()> {
+        // virtio-v1.1-csprd01, 5.1.4
+        None
+    }
+
+    fn read(&self, offset: usize, size: u8) -> Option<u32> {
+        match (size, offset) {
+            (1, 0..=6) => Some(self.mac[offset] as u32),
+            (2, 6) => Some(self.status as u32),
+            (2, 8) => Some(self.max_virtqueue_pairs as u32),
+            (2, 10) => Some(self.mtu as u32),
+            _ => None,
+        }
+    }
+
+    fn reset(&mut self) {
+        self.status = 0;
+        self.gen += 1;
+    }
+
+    fn generation(&self) -> u32 {
+        self.gen
+    }
+}
+
+impl VirtioDevice {
+    pub fn new_vmnet(
+        name: String,
+        irq: u32,
+        irq_sender: Sender<u32>,
+        gpa2hva: AddressConverter,
+    ) -> Self {
+        let mut interface = 0;
+        let mut mac = vec![0u8; 17];
+        let mut mtu = 0u16;
+        let ret = unsafe { create_interface(&mut interface, mac.as_mut_ptr(), &mut mtu) };
+        if ret != 0 {
+            panic!("cannot create vmnet interface. root privilege is required.");
+        }
+        let mac_vec: Vec<u8> = String::from_utf8(mac)
+            .unwrap()
+            .split(':')
+            .map(|c| u8::from_str_radix(c, 16).unwrap())
+            .collect();
+        let mut mac = [0u8; 6];
+        mac.copy_from_slice(&mac_vec);
+        let net_cfg = VirtioNetCfg {
+            mac,
+            status: 0,
+            max_virtqueue_pairs: 1,
+            mtu,
+            gen: 0,
+        };
+
+        let isr = Arc::new(RwLock::new(0));
+        let rx = VirtqManager::new(
+            format!("{}_rx", name),
+            64,
+            net_rx_srv(interface),
+            irq,
+            irq_sender.clone(),
+            isr.clone(),
+            gpa2hva.clone(),
+        );
+        let tx = VirtqManager::new(
+            format!("{}_tx", name),
+            64,
+            net_tx_srv(interface),
+            irq,
+            irq_sender.clone(),
+            isr.clone(),
+            gpa2hva.clone(),
+        );
+        let vqs = vec![rx, tx];
+
+        VirtioDevice {
+            name,
+            dev_id: VirtioId::Net,
+            dev_feat: (1 << VIRTIO_F_VERSION_1) | (1 << VIRTIO_NET_F_MAC) | (1 << VIRTIO_NET_F_MTU),
+            dri_feat: 0,
+            dev_feat_sel: 0,
+            dri_feat_sel: 0,
+            qsel: 0,
+            cfg: Box::new(net_cfg),
+            vqs,
+            isr,
+            status: 0,
+            cfg_gen: 0,
+            irq,
+        }
+    }
+}
+
+impl VirtioMmioDev {
+    pub fn new_vmnet(
+        addr: usize,
+        irq: u32,
+        name: String,
+        irq_sender: Sender<u32>,
+        gpa2hva: AddressConverter,
+    ) -> Self {
+        let vmnet = VirtioDevice::new_vmnet(name, irq, irq_sender, gpa2hva);
+        VirtioMmioDev { addr, dev: vmnet }
+    }
+}

--- a/xhype/xhype/src/virtio/virtq.rs
+++ b/xhype/xhype/src/virtio/virtq.rs
@@ -1,0 +1,226 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+
+use super::{
+    channel, AddressConverter, IrqSender, Sender, TaskReceiver, TaskSender, VirtqReceiver,
+    VirtqSender,
+};
+use std::mem::size_of;
+use std::sync::{Arc, RwLock};
+
+// https://docs.oasis-open.org/virtio/virtio/v1.1/csprd01/listings/virtio_queue.h
+
+/* This marks a buffer as continuing via the next field. */
+pub const VIRTQ_DESC_F_NEXT: u16 = 1;
+/* This marks a buffer as write-only (otherwise read-only). */
+pub const VIRTQ_DESC_F_WRITE: u16 = 2;
+/* This means the buffer contains a list of buffer descriptors. */
+pub const VIRTQ_DESC_F_INDIRECT: u16 = 4;
+
+/* The device uses this in used->flags to advise the driver: don't kick me
+ * when you add a buffer.  It's unreliable, so it's simply an
+ * optimization. */
+pub const VIRTQ_USED_F_NO_NOTIFY: u16 = 1;
+/* The driver uses this in avail->flags to advise the device: don't
+ * interrupt me when you consume a buffer.  It's unreliable, so it's
+ * simply an optimization.  */
+pub const VIRTQ_AVAIL_F_NO_INTERRUPT: u16 = 1;
+
+/* Support for indirect descriptors */
+pub const VIRTIO_F_INDIRECT_DESC: u16 = 28;
+
+/* Support for avail_event and used_event fields */
+pub const VIRTIO_F_EVENT_IDX: u16 = 29;
+
+/* Arbitrary descriptor layouts. */
+pub const VIRTIO_F_ANY_LAYOUT: u16 = 27;
+
+pub const VIRTQ_SIZE_MAX: u16 = 1 << 15;
+
+#[repr(C, packed)]
+pub struct VirtqDesc {
+    pub addr: u64,
+    pub len: u32,
+    pub flags: u16,
+    pub next: u16,
+}
+
+#[repr(C, packed)]
+pub struct VirtqUsedElem {
+    pub id: u32,
+    pub len: u32,
+}
+
+#[derive(Debug, Clone)]
+pub struct Virtq<T> {
+    pub num: u32,
+    pub desc: T,
+    pub avail: T,
+    pub used: T,
+}
+
+impl<T> Virtq<T>
+where
+    T: Default,
+{
+    pub fn new(num: u32) -> Self {
+        Virtq {
+            num,
+            desc: T::default(),
+            avail: T::default(),
+            used: T::default(),
+        }
+    }
+}
+
+// Virtq where all addresses are guest physical addresses
+impl Virtq<u64> {
+    pub fn to_hva<C>(&self, convert: C) -> Virtq<usize>
+    where
+        C: Fn(u64) -> usize,
+    {
+        Virtq {
+            num: self.num,
+            desc: convert(self.desc),
+            avail: convert(self.avail),
+            used: convert(self.used),
+        }
+    }
+}
+
+// Virtq where all addresses are host virtual addresses
+impl Virtq<usize> {
+    pub fn read_desc(&self, index: u16) -> VirtqDesc {
+        let real_index = index as usize % self.num as usize;
+        let ptr = (self.desc + size_of::<VirtqDesc>() * real_index) as *const VirtqDesc;
+        unsafe { ptr.read() }
+    }
+
+    pub fn push_used(&self, id: u16, len: u32) {
+        let used_index = self.used_index();
+        let real_used_index = used_index as usize % self.num as usize;
+        let used_elem = VirtqUsedElem { id: id as u32, len };
+        let ptr_elem =
+            (self.used + 4 + size_of::<VirtqUsedElem>() * real_used_index) as *mut VirtqUsedElem;
+        unsafe {
+            ptr_elem.write(used_elem);
+        }
+        self.set_used_index(used_index.wrapping_add(1));
+    }
+
+    pub fn used_flags(&self) -> u16 {
+        let ptr = self.used as *const u16;
+        unsafe { ptr.read() }
+    }
+
+    pub fn used_index(&self) -> u16 {
+        let ptr = (self.used + 2) as *const u16;
+        unsafe { ptr.read() }
+    }
+
+    fn set_used_index(&self, index: u16) {
+        let ptr = (self.used + 2) as *mut u16;
+        unsafe { ptr.write(index) }
+    }
+
+    pub fn set_used_flags(&self, flags: u16) {
+        let ptr = self.used as *mut u16;
+        unsafe { ptr.write(flags) }
+    }
+
+    pub fn read_avail(&self, index: u16) -> u16 {
+        let real_index = index as usize % self.num as usize;
+        let ptr = (self.avail + 4 + size_of::<u16>() * real_index) as *const u16;
+        unsafe { ptr.read() }
+    }
+
+    pub fn avail_flags(&self) -> u16 {
+        let ptr = self.avail as *const u16;
+        unsafe { ptr.read() }
+    }
+
+    pub fn avail_index(&self) -> u16 {
+        let ptr = (self.avail + 2) as *const u16;
+        unsafe { ptr.read() }
+    }
+
+    pub fn get_avail<C>(
+        &self,
+        index: u16,
+        converter: C,
+    ) -> (Vec<(usize, usize)>, Vec<(usize, usize)>)
+    where
+        C: Fn(u64) -> usize,
+    {
+        let desc_head = self.read_avail(index);
+        let mut desc_index = desc_head;
+        let mut readable = Vec::new();
+        let mut writable = Vec::new();
+        loop {
+            let desc = self.read_desc(desc_index);
+            if desc.flags & VIRTQ_DESC_F_WRITE == 0 {
+                readable.push((converter(desc.addr), desc.len as usize));
+            } else {
+                writable.push((converter(desc.addr), desc.len as usize));
+            }
+            if desc.flags & VIRTQ_DESC_F_NEXT > 0 {
+                desc_index = desc.next;
+            } else {
+                break;
+            }
+        }
+        (readable, writable)
+    }
+}
+
+pub struct VirtqManager {
+    pub name: String,
+    pub qnum_max: u32,
+    pub qready: u32,
+    pub virtq: Virtq<u64>,
+    pub task_sender: TaskSender,
+    pub virtq_sender: VirtqSender,
+}
+
+pub type VirtioVqSrv = Box<
+    dyn Fn(TaskReceiver, VirtqReceiver, u32, IrqSender, Arc<RwLock<u32>>, AddressConverter)
+        + Send
+        + Sync
+        + 'static,
+>;
+
+impl VirtqManager {
+    pub fn new(
+        name: String,
+        qnum_max: u32,
+        srv: VirtioVqSrv,
+        irq: u32,
+        irq_sender: Sender<u32>,
+        isr: Arc<RwLock<u32>>,
+        gpa2hva: AddressConverter,
+    ) -> Self {
+        let (task_sender, task_receiver) = channel();
+        let (virtq_sender, virtq_receiver) = channel();
+        std::thread::Builder::new()
+            .name(name.clone())
+            .spawn(move || srv(task_receiver, virtq_receiver, irq, irq_sender, isr, gpa2hva))
+            .expect(&format!("cannot create thread for virtq {}", &name));
+        VirtqManager {
+            name,
+            qnum_max,
+            qready: 0,
+            virtq: Virtq::new(0),
+            task_sender: task_sender,
+            virtq_sender,
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    #[test]
+    fn virtq_struct_size_test() {
+        assert_eq!(size_of::<VirtqUsedElem>(), 8);
+        assert_eq!(size_of::<VirtqDesc>(), 16);
+    }
+}


### PR DESCRIPTION
Current virtio-net device is based on [vmnet](https://developer.apple.com/documentation/vmnet). The Implementation is inspired by [Akaros/user/vmm/virtio_mmio.c](https://github.com/akaros/akaros/blob/master/user/vmm/virtio_mmio.c) and [xhyve/src/pci_virtio_net_vmnet.c](https://github.com/machyve/xhyve/blob/master/src/pci_virtio_net_vmnet.c)