### PR TITLE
add more debug info for firmware debug

### DIFF
--- a/xhype/xhype/examples/firmware_test.rs
+++ b/xhype/xhype/examples/firmware_test.rs
@@ -62,7 +62,11 @@ fn load_firemware(
         0,
     );
 
-    let ctrl_cpu2 = gen_exec_ctrl(vmx_read_capability(VMXCap::CPU2)?, 0, 0);
+    let ctrl_cpu2 = gen_exec_ctrl(
+        vmx_read_capability(VMXCap::CPU2)?,
+        CPU_BASED2_RDTSCP | CPU_BASED2_INVPCID,
+        0,
+    );
     let ctrl_entry = gen_exec_ctrl(vmx_read_capability(VMXCap::Entry)?, 0, 0);
     let cr0 = X86_CR0_NE;
     let cr4 = X86_CR4_VMXE;

--- a/xhype/xhype/src/hv/mod.rs
+++ b/xhype/xhype/src/hv/mod.rs
@@ -32,6 +32,7 @@ pub mod vmx;
 use crate::consts::msr::*;
 use crate::err::Error;
 use ffi::*;
+use log::debug;
 use vmx::*;
 
 #[inline]
@@ -200,167 +201,167 @@ impl VCPU {
     }
 
     pub fn dump(&self) -> Result<(), Error> {
-        println!(
+        debug!(
             "VMCS_CTRL_PIN_BASED: {:x}",
             self.read_vmcs(VMCS_CTRL_PIN_BASED)?
         );
-        println!(
+        debug!(
             "VMCS_CTRL_CPU_BASED: {:x}",
             self.read_vmcs(VMCS_CTRL_CPU_BASED)?
         );
-        println!(
+        debug!(
             "VMCS_CTRL_CPU_BASED2: {:x}",
             self.read_vmcs(VMCS_CTRL_CPU_BASED2)?
         );
-        println!(
+        debug!(
             "VMCS_CTRL_VMENTRY_CONTROLS: {:x}",
             self.read_vmcs(VMCS_CTRL_VMENTRY_CONTROLS)?
         );
-        println!(
+        debug!(
             "VMCS_CTRL_EXC_BITMAP: {:x}",
             self.read_vmcs(VMCS_CTRL_EXC_BITMAP)?
         );
-        println!(
+        debug!(
             "VMCS_CTRL_CR0_MASK: {:x}",
             self.read_vmcs(VMCS_CTRL_CR0_MASK)?
         );
-        println!(
+        debug!(
             "VMCS_CTRL_CR0_SHADOW: {:x}",
             self.read_vmcs(VMCS_CTRL_CR0_SHADOW)?
         );
-        println!(
+        debug!(
             "VMCS_CTRL_CR4_MASK: {:x}",
             self.read_vmcs(VMCS_CTRL_CR4_MASK)?
         );
-        println!(
+        debug!(
             "VMCS_CTRL_CR4_SHADOW: {:x}",
             self.read_vmcs(VMCS_CTRL_CR4_SHADOW)?
         );
-        println!("VMCS_GUEST_CS: {:x}", self.read_vmcs(VMCS_GUEST_CS)?);
-        println!(
+        debug!("VMCS_GUEST_CS: {:x}", self.read_vmcs(VMCS_GUEST_CS)?);
+        debug!(
             "VMCS_GUEST_CS_LIMIT: {:x}",
             self.read_vmcs(VMCS_GUEST_CS_LIMIT)?
         );
-        println!("VMCS_GUEST_CS_AR: {:x}", self.read_vmcs(VMCS_GUEST_CS_AR)?);
-        println!(
+        debug!("VMCS_GUEST_CS_AR: {:x}", self.read_vmcs(VMCS_GUEST_CS_AR)?);
+        debug!(
             "VMCS_GUEST_CS_BASE: {:x}",
             self.read_vmcs(VMCS_GUEST_CS_BASE)?
         );
-        println!("VMCS_GUEST_DS: {:x}", self.read_vmcs(VMCS_GUEST_DS)?);
-        println!(
+        debug!("VMCS_GUEST_DS: {:x}", self.read_vmcs(VMCS_GUEST_DS)?);
+        debug!(
             "VMCS_GUEST_DS_LIMIT: {:x}",
             self.read_vmcs(VMCS_GUEST_DS_LIMIT)?
         );
-        println!("VMCS_GUEST_DS_AR: {:x}", self.read_vmcs(VMCS_GUEST_DS_AR)?);
-        println!(
+        debug!("VMCS_GUEST_DS_AR: {:x}", self.read_vmcs(VMCS_GUEST_DS_AR)?);
+        debug!(
             "VMCS_GUEST_DS_BASE: {:x}",
             self.read_vmcs(VMCS_GUEST_DS_BASE)?
         );
-        println!("VMCS_GUEST_ES: {:x}", self.read_vmcs(VMCS_GUEST_ES)?);
-        println!(
+        debug!("VMCS_GUEST_ES: {:x}", self.read_vmcs(VMCS_GUEST_ES)?);
+        debug!(
             "VMCS_GUEST_ES_LIMIT: {:x}",
             self.read_vmcs(VMCS_GUEST_ES_LIMIT)?
         );
-        println!("VMCS_GUEST_ES_AR: {:x}", self.read_vmcs(VMCS_GUEST_ES_AR)?);
-        println!(
+        debug!("VMCS_GUEST_ES_AR: {:x}", self.read_vmcs(VMCS_GUEST_ES_AR)?);
+        debug!(
             "VMCS_GUEST_ES_BASE: {:x}",
             self.read_vmcs(VMCS_GUEST_ES_BASE)?
         );
-        println!("VMCS_GUEST_FS: {:x}", self.read_vmcs(VMCS_GUEST_FS)?);
-        println!(
+        debug!("VMCS_GUEST_FS: {:x}", self.read_vmcs(VMCS_GUEST_FS)?);
+        debug!(
             "VMCS_GUEST_FS_LIMIT: {:x}",
             self.read_vmcs(VMCS_GUEST_FS_LIMIT)?
         );
-        println!("VMCS_GUEST_FS_AR: {:x}", self.read_vmcs(VMCS_GUEST_FS_AR)?);
-        println!(
+        debug!("VMCS_GUEST_FS_AR: {:x}", self.read_vmcs(VMCS_GUEST_FS_AR)?);
+        debug!(
             "VMCS_GUEST_FS_BASE: {:x}",
             self.read_vmcs(VMCS_GUEST_FS_BASE)?
         );
-        println!("VMCS_GUEST_GS: {:x}", self.read_vmcs(VMCS_GUEST_GS)?);
-        println!(
+        debug!("VMCS_GUEST_GS: {:x}", self.read_vmcs(VMCS_GUEST_GS)?);
+        debug!(
             "VMCS_GUEST_GS_LIMIT: {:x}",
             self.read_vmcs(VMCS_GUEST_GS_LIMIT)?
         );
-        println!("VMCS_GUEST_GS_AR: {:x}", self.read_vmcs(VMCS_GUEST_GS_AR)?);
-        println!(
+        debug!("VMCS_GUEST_GS_AR: {:x}", self.read_vmcs(VMCS_GUEST_GS_AR)?);
+        debug!(
             "VMCS_GUEST_GS_BASE: {:x}",
             self.read_vmcs(VMCS_GUEST_GS_BASE)?
         );
-        println!("VMCS_GUEST_SS: {:x}", self.read_vmcs(VMCS_GUEST_SS)?);
-        println!(
+        debug!("VMCS_GUEST_SS: {:x}", self.read_vmcs(VMCS_GUEST_SS)?);
+        debug!(
             "VMCS_GUEST_SS_LIMIT: {:x}",
             self.read_vmcs(VMCS_GUEST_SS_LIMIT)?
         );
-        println!("VMCS_GUEST_SS_AR: {:x}", self.read_vmcs(VMCS_GUEST_SS_AR)?);
-        println!(
+        debug!("VMCS_GUEST_SS_AR: {:x}", self.read_vmcs(VMCS_GUEST_SS_AR)?);
+        debug!(
             "VMCS_GUEST_SS_BASE: {:x}",
             self.read_vmcs(VMCS_GUEST_SS_BASE)?
         );
-        println!("VMCS_GUEST_TR: {:x}", self.read_vmcs(VMCS_GUEST_TR)?);
-        println!(
+        debug!("VMCS_GUEST_TR: {:x}", self.read_vmcs(VMCS_GUEST_TR)?);
+        debug!(
             "VMCS_GUEST_TR_LIMIT: {:x}",
             self.read_vmcs(VMCS_GUEST_TR_LIMIT)?
         );
-        println!("VMCS_GUEST_TR_AR: {:x}", self.read_vmcs(VMCS_GUEST_TR_AR)?);
-        println!(
+        debug!("VMCS_GUEST_TR_AR: {:x}", self.read_vmcs(VMCS_GUEST_TR_AR)?);
+        debug!(
             "VMCS_GUEST_TR_BASE: {:x}",
             self.read_vmcs(VMCS_GUEST_TR_BASE)?
         );
-        println!("VMCS_GUEST_LDTR: {:x}", self.read_vmcs(VMCS_GUEST_LDTR)?);
-        println!(
+        debug!("VMCS_GUEST_LDTR: {:x}", self.read_vmcs(VMCS_GUEST_LDTR)?);
+        debug!(
             "VMCS_GUEST_LDTR_LIMIT: {:x}",
             self.read_vmcs(VMCS_GUEST_LDTR_LIMIT)?
         );
-        println!(
+        debug!(
             "VMCS_GUEST_LDTR_AR: {:x}",
             self.read_vmcs(VMCS_GUEST_LDTR_AR)?
         );
-        println!(
+        debug!(
             "VMCS_GUEST_LDTR_BASE: {:x}",
             self.read_vmcs(VMCS_GUEST_LDTR_BASE)?
         );
-        println!(
+        debug!(
             "VMCS_GUEST_GDTR_BASE: {:x}",
             self.read_vmcs(VMCS_GUEST_GDTR_BASE)?
         );
-        println!(
+        debug!(
             "VMCS_GUEST_GDTR_LIMIT: {:x}",
             self.read_vmcs(VMCS_GUEST_GDTR_LIMIT)?
         );
-        println!(
+        debug!(
             "VMCS_GUEST_IDTR_LIMIT: {:x}",
             self.read_vmcs(VMCS_GUEST_IDTR_LIMIT)?
         );
-        println!(
+        debug!(
             "VMCS_GUEST_IDTR_BASE: {:x}",
             self.read_vmcs(VMCS_GUEST_IDTR_BASE)?
         );
-        println!(
+        debug!(
             "VMCS_GUEST_IA32_EFER: {:x}",
             self.read_vmcs(VMCS_GUEST_IA32_EFER)?
         );
-        println!("RIP: {:x}", self.read_reg(X86Reg::RIP)?);
-        println!("RFLAGS: {:x}", self.read_reg(X86Reg::RFLAGS)?);
-        println!("RAX: {:x}", self.read_reg(X86Reg::RAX)?);
-        println!("RCX: {:x}", self.read_reg(X86Reg::RCX)?);
-        println!("RDX: {:x}", self.read_reg(X86Reg::RDX)?);
-        println!("RBX: {:x}", self.read_reg(X86Reg::RBX)?);
-        println!("RSI: {:x}", self.read_reg(X86Reg::RSI)?);
-        println!("RDI: {:x}", self.read_reg(X86Reg::RDI)?);
-        println!("RSP: {:x}", self.read_reg(X86Reg::RSP)?);
-        println!("RBP: {:x}", self.read_reg(X86Reg::RBP)?);
-        println!("R8: {:x}", self.read_reg(X86Reg::R8)?);
-        println!("R9: {:x}", self.read_reg(X86Reg::R9)?);
-        println!("R10: {:x}", self.read_reg(X86Reg::R10)?);
-        println!("R11: {:x}", self.read_reg(X86Reg::R11)?);
-        println!("R12: {:x}", self.read_reg(X86Reg::R12)?);
-        println!("R13: {:x}", self.read_reg(X86Reg::R13)?);
-        println!("R14: {:x}", self.read_reg(X86Reg::R14)?);
-        println!("R15: {:x}", self.read_reg(X86Reg::R15)?);
-        println!("CR0: {:x}", self.read_reg(X86Reg::CR0)?);
-        println!("CR2: {:x}", self.read_reg(X86Reg::CR2)?);
-        println!("CR3: {:x}", self.read_reg(X86Reg::CR3)?);
-        println!("CR4: {:x}", self.read_reg(X86Reg::CR4)?);
+        debug!("RIP: {:x}", self.read_reg(X86Reg::RIP)?);
+        debug!("RFLAGS: {:x}", self.read_reg(X86Reg::RFLAGS)?);
+        debug!("RAX: {:x}", self.read_reg(X86Reg::RAX)?);
+        debug!("RCX: {:x}", self.read_reg(X86Reg::RCX)?);
+        debug!("RDX: {:x}", self.read_reg(X86Reg::RDX)?);
+        debug!("RBX: {:x}", self.read_reg(X86Reg::RBX)?);
+        debug!("RSI: {:x}", self.read_reg(X86Reg::RSI)?);
+        debug!("RDI: {:x}", self.read_reg(X86Reg::RDI)?);
+        debug!("RSP: {:x}", self.read_reg(X86Reg::RSP)?);
+        debug!("RBP: {:x}", self.read_reg(X86Reg::RBP)?);
+        debug!("R8: {:x}", self.read_reg(X86Reg::R8)?);
+        debug!("R9: {:x}", self.read_reg(X86Reg::R9)?);
+        debug!("R10: {:x}", self.read_reg(X86Reg::R10)?);
+        debug!("R11: {:x}", self.read_reg(X86Reg::R11)?);
+        debug!("R12: {:x}", self.read_reg(X86Reg::R12)?);
+        debug!("R13: {:x}", self.read_reg(X86Reg::R13)?);
+        debug!("R14: {:x}", self.read_reg(X86Reg::R14)?);
+        debug!("R15: {:x}", self.read_reg(X86Reg::R15)?);
+        debug!("CR0: {:x}", self.read_reg(X86Reg::CR0)?);
+        debug!("CR2: {:x}", self.read_reg(X86Reg::CR2)?);
+        debug!("CR3: {:x}", self.read_reg(X86Reg::CR3)?);
+        debug!("CR4: {:x}", self.read_reg(X86Reg::CR4)?);
         Ok(())
     }
 

--- a/xhype/xhype/src/lib.rs
+++ b/xhype/xhype/src/lib.rs
@@ -325,8 +325,10 @@ impl GuestThread {
             let rip = vcpu.read_reg(X86Reg::RIP)?;
             let instr_len = vcpu.read_vmcs(VMCS_RO_VMEXIT_INSTR_LEN)?;
             trace!(
-                "vm exit reason = {}, rip = {:x}, len = {}",
+                "vm exit reason = {}, cs = {:x}, cs base = {:x}, rip = {:x}, len = {}",
                 reason,
+                vcpu.read_reg(X86Reg::CS)?,
+                vcpu.read_vmcs(VMCS_GUEST_CS_BASE)?,
                 rip,
                 instr_len
             );
@@ -385,6 +387,9 @@ impl GuestThread {
                     let err_msg =
                         format!("handler for vm exit code 0x{:x} is not implemented", reason);
                     error!("{}", err_msg);
+                    if reason & (1 << 31) > 0 {
+                        vcpu.dump().unwrap();
+                    }
                     Err((reason, err_msg))?
                 }
             };

--- a/xhype/xhype/src/vmexit.rs
+++ b/xhype/xhype/src/vmexit.rs
@@ -64,6 +64,7 @@ fn pml4_index(addr: u64) -> u64 {
     (addr >> 39) & 0x1ff
 }
 
+/// only supports 4-level paging
 pub(crate) unsafe fn emulate_paging(
     vcpu: &VCPU,
     gth: &GuestThread,
@@ -74,31 +75,75 @@ pub(crate) unsafe fn emulate_paging(
         return Ok(linear_addr);
     }
     let cr3 = vcpu.read_reg(X86Reg::CR3)?;
+    trace!("linear address = {:x}, cr3 = {:x}", linear_addr, cr3);
+    trace!("linear address components: pml4_index = {:x}, pdpt_index = {:x}, pd_index = {:x}, pt_index = {:x}", pml4_index(linear_addr), pdpt_index(linear_addr), pd_index(linear_addr), pt_index(linear_addr));
+    for i in pml4_index(linear_addr).checked_sub(5).unwrap_or(0)
+        ..std::cmp::min(pml4_index(linear_addr) + 5, 512)
+    {
+        trace!(
+            "pml4 entry {} = {:x}",
+            i,
+            *gth.vm.read_guest_mem::<u64>((cr3 & !0xfff) & ADDR_MASK, i)
+        )
+    }
     let pml4e: u64 = *gth
         .vm
         .read_guest_mem((cr3 & !0xfff) & ADDR_MASK, pml4_index(linear_addr));
+    trace!("pml4e = {:x}", pml4e);
     if pml4e & PG_P == 0 {
         return Err("emulate_paging: page fault at pml4e".to_string())?;
+    }
+    for i in pdpt_index(linear_addr).checked_sub(5).unwrap_or(0)
+        ..std::cmp::min(pdpt_index(linear_addr) + 5, 512)
+    {
+        trace!(
+            "pdpt entry {} = {:x}",
+            i,
+            *gth.vm
+                .read_guest_mem::<u64>((pml4e & !0xfff) & ADDR_MASK, i)
+        )
     }
     let pdpte: u64 = *gth
         .vm
         .read_guest_mem((pml4e & !0xfff) & ADDR_MASK, pdpt_index(linear_addr));
+    trace!("pdpte = {:x}", pdpte);
     if pdpte & PG_P == 0 {
         return Err("emulate_paging: page fault at pdpte".to_string())?;
     } else if pdpte & PG_PS > 0 {
         return Ok((pdpte & !0x3fffffff) | (linear_addr & 0x3fffffff));
     }
+    for i in pd_index(linear_addr).checked_sub(5).unwrap_or(0)
+        ..std::cmp::min(pd_index(linear_addr) + 5, 512)
+    {
+        trace!(
+            "pd entry {} = {:x}",
+            i,
+            *gth.vm
+                .read_guest_mem::<u64>((pdpte & !0xfff) & ADDR_MASK, i)
+        )
+    }
     let pde: u64 = *gth
         .vm
         .read_guest_mem((pdpte & !0xfff) & ADDR_MASK, pd_index(linear_addr));
+    trace!("pde = {:x}", pde);
     if pde & PG_P == 0 {
         return Err("emulate_paging: page fault at pde".to_string())?;
     } else if pde & PG_PS > 0 {
         return Ok((pde & !0x1fffff) | (linear_addr & 0x1fffff));
     }
+    for i in pt_index(linear_addr).checked_sub(5).unwrap_or(0)
+        ..std::cmp::min(pt_index(linear_addr) + 5, 512)
+    {
+        trace!(
+            "pt entry {} = {:x}",
+            i,
+            *gth.vm.read_guest_mem::<u64>((pde & !0xfff) & ADDR_MASK, i)
+        )
+    }
     let pte: u64 = *gth
         .vm
         .read_guest_mem((pde & !0xfff) & ADDR_MASK, pt_index(linear_addr));
+    trace!("pte = {:x}", pte);
     if pte & PG_P == 0 {
         return Err("emulate_paging: page fault at pte".to_string())?;
     } else {

--- a/xhype/xhype/src/vmexit.rs
+++ b/xhype/xhype/src/vmexit.rs
@@ -599,6 +599,25 @@ pub fn handle_io(vcpu: &VCPU, gth: &GuestThread) -> Result<HandleResult, Error> 
 // VMX_REASON_EPT_VIOLATION
 ////////////////////////////////////////////////////////////////////////////////
 
+pub fn ept_qual_description(qual: u64) -> String {
+    let mut description = format!(
+        "qual={:x}, read = {}, write = {}, instruction fetch = {}. valid = {}, page_walk = {}",
+        qual,
+        ept_read(qual),
+        ept_write(qual),
+        ept_instr_fetch(qual),
+        ept_valid(qual),
+        ept_page_walk(qual)
+    );
+
+    description
+    // format!("qual={:x}, read = {}, write = {}, instruction fetch = {}, valid = ")
+}
+
+pub fn ept_valid(qual: u64) -> bool {
+    qual & (1 << 7) > 0
+}
+
 pub fn ept_read(qual: u64) -> bool {
     qual & 1 > 0
 }

--- a/xhype/xhype/src/vmexit.rs
+++ b/xhype/xhype/src/vmexit.rs
@@ -475,7 +475,7 @@ pub fn handle_io(vcpu: &VCPU, gth: &GuestThread) -> Result<HandleResult, Error> 
                 let v = gth.vm.rtc.read().unwrap().read();
                 vcpu.write_reg_16_low(X86Reg::RAX, v)?;
             } else {
-                unimplemented!();
+                error!("guest writes {:x} to RTC port {:x}", rax, RTC_PORT_DATA);
             }
         }
         COM1_BASE..=COM1_MAX => {
@@ -514,7 +514,7 @@ pub fn handle_io(vcpu: &VCPU, gth: &GuestThread) -> Result<HandleResult, Error> 
                     pic_bus.write((rax & 0xffffffff) as u32);
                 } else {
                     // to do:
-                    unimplemented!("guest writes non-4-byte data to pci");
+                    error!("guest writes non-4-byte data to pci, data = {:x}, size = {}, port = {:x}, current cf8 = {:x}", rax, size, port, gth.vm.pci_bus.lock().unwrap().config_addr.0);
                 }
             }
         }

--- a/xhype/xhype/src/vmexit.rs
+++ b/xhype/xhype/src/vmexit.rs
@@ -219,7 +219,13 @@ pub fn handle_cr(vcpu: &VCPU, _gth: &GuestThread) -> Result<HandleResult, Error>
                     let mut ctrl_entry = vcpu.read_vmcs(VMCS_CTRL_VMENTRY_CONTROLS)?;
                     ctrl_entry |= VMENTRY_GUEST_IA32E;
                     vcpu.write_vmcs(VMCS_CTRL_VMENTRY_CONTROLS, ctrl_entry)?;
+                    // to do: check more segment registers according to
+                    // 26.3.1.2 Checks on Guest Segment Registers
+                    vcpu.write_vmcs(VMCS_GUEST_TR_AR, 0x8b)?;
+                    warn!("long mode is turned on");
+                    vcpu.dump().unwrap();
                 } else if !long_mode && efer & EFER_LMA != 0 {
+                    warn!("long mode turned off");
                     efer &= !EFER_LMA;
                     vcpu.write_vmcs(VMCS_GUEST_IA32_EFER, efer)?;
                     let mut ctrl_entry = vcpu.read_vmcs(VMCS_CTRL_VMENTRY_CONTROLS)?;


### PR DESCRIPTION
This PR adds more log information for firmware debug. It also mandatorily changes TR access to `0x8b` to avoid vm entry fail.
To-do: check more segment registers before the guest jumps to long mode.