### PR TITLE
xhype: set type_of_loader in setup_header

### DIFF
--- a/xhype/xhype/src/linux.rs
+++ b/xhype/xhype/src/linux.rs
@@ -216,6 +216,7 @@ pub fn load_linux64(
 
     let mut bp = BootParams::new();
     bp.hdr = header;
+    bp.hdr.type_of_loader = 0xff;
 
     // load kernel
     let kernel_offset = (bp.hdr.setup_sects as u64 + 1) * 512;


### PR DESCRIPTION
Linux ignores the initramfs if type_of_loader is not set. See reserve_initrd() in Linux source code
arch/x86/kernel/setup.c.

https://github.com/torvalds/linux/blob/52a93d39b17dc7eb98b6aa3edb93943248e03b2f/arch/x86/kernel/setup.c#L305